### PR TITLE
:arrow_up: Allow to work under Lua >= 5.2

### DIFF
--- a/lib/gc_metatable.lua
+++ b/lib/gc_metatable.lua
@@ -3,10 +3,14 @@
 -- https://stackoverflow.com/questions/27426704/lua-5-1-workaround-for-gc-metamethod-for-tables
 
 return function(t, gc_fn)
-    local mt = {}
-    mt.__gc = gc_fn
+  local mt = {}
+  mt.__gc = gc_fn
+  if _VERSION == 'Lua 5.1' then
     local prox = newproxy(true)
-    getmetatable(prox).__gc = function() mt.__gc(t) end
+    getmetatable(prox).__gc = function()
+      mt.__gc(t)
+    end
     t[prox] = true
-    setmetatable(t, mt)
+  end
+  setmetatable(t, mt)
 end


### PR DESCRIPTION
Problem:
- Using `newproxy` as a workaround for allowing garbage collection on tables is not needed on Lua >= 5.2

Solution:
- Only apply the `newproxy` usage on Lua 5.1